### PR TITLE
Fix success field type causing ServiceNow change completion failures

### DIFF
--- a/internal/notifier/handler.go
+++ b/internal/notifier/handler.go
@@ -14,7 +14,7 @@ type Payload struct {
 	Description string `json:"description"`
 	StartTime   string `json:"startTime"`
 	EndTime     string `json:"endTime"`
-	Success     bool   `json:"success,omitempty"`
+	Success     string `json:"success,omitempty"`
 }
 
 // Message represents a change event
@@ -45,7 +45,7 @@ func (p *Payload) SetMsg(record *events.DynamoDBEventRecord) (*Message, error) {
 
 	// construct payloads
 	if record.Change.NewImage["status"].String() == "In Progress" || record.Change.NewImage["status"].String() == "Completed" {
-		p.Success = true
+		p.Success = "true"
 		m = Message{
 			MessageID: "HO_SIAM_IN_REST_CHG_UPDATE_JSON",
 			IntID:     record.Change.NewImage["internal_identifier"].String(),

--- a/internal/notifier/handler_test.go
+++ b/internal/notifier/handler_test.go
@@ -9,14 +9,16 @@ import (
 func TestSetMsg(t *testing.T) {
 
 	tt := []struct {
-		name   string
-		event  string
-		status string
-		expect string
+		name          string
+		event         string
+		status        string
+		expect        string
+		expectSuccess string
 	}{
-		{name: "create", event: "INSERT", status: "Scheduled", expect: "HO_SIAM_IN_REST_CHG_POST_JSON"},
-		{name: "update", event: "MODIFY", status: "In Progress", expect: "HO_SIAM_IN_REST_CHG_UPDATE_JSON"},
-		{name: "delete", event: "REMOVE", expect: ""},
+		{name: "create", event: "INSERT", status: "Scheduled", expect: "HO_SIAM_IN_REST_CHG_POST_JSON", expectSuccess: ""},
+		{name: "update", event: "MODIFY", status: "In Progress", expect: "HO_SIAM_IN_REST_CHG_UPDATE_JSON", expectSuccess: "true"},
+		{name: "complete", event: "MODIFY", status: "Completed", expect: "HO_SIAM_IN_REST_CHG_UPDATE_JSON", expectSuccess: "true"},
+		{name: "delete", event: "REMOVE", expect: "", expectSuccess: ""},
 	}
 
 	for _, tc := range tt {
@@ -42,8 +44,11 @@ func TestSetMsg(t *testing.T) {
 			}
 
 			if msg.MessageID != tc.expect {
-				t.Errorf("expected %v, got %v", tc.expect, msg.MessageID)
+				t.Errorf("expected MessageID %v, got %v", tc.expect, msg.MessageID)
+			}
 
+			if msg.Success != tc.expectSuccess {
+				t.Errorf("expected Success %q, got %q", tc.expectSuccess, msg.Success)
 			}
 		})
 	}

--- a/internal/notifier/notify.go
+++ b/internal/notifier/notify.go
@@ -67,8 +67,16 @@ func (m *Message) Notify() (string, error) {
 		return "", err
 	}
 
+	// check for error response from SNOW
+	if _, hasErr := dat["error"]; hasErr {
+		return "", errors.New("SNOW returned error: " + string(body))
+	}
+
 	// check for internal_identifier
-	rts := dat["result"].(map[string]interface{})
+	rts, ok := dat["result"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("unexpected SNOW response format: " + string(body))
+	}
 	ini := rts["internal_identifier"].(string)
 	if ini == "" {
 		return ini, errors.New("request failed, SNOW did not return a Change ID")

--- a/internal/notifier/notify.go
+++ b/internal/notifier/notify.go
@@ -77,13 +77,16 @@ func (m *Message) Notify() (string, error) {
 	if !ok {
 		return "", errors.New("unexpected SNOW response format: " + string(body))
 	}
-	ini := rts["internal_identifier"].(string)
-	if ini == "" {
-		return ini, errors.New("request failed, SNOW did not return a Change ID")
+	ini, ok := rts["internal_identifier"].(string)
+	if !ok || ini == "" {
+		return "", errors.New("unexpected or missing internal_identifier in SNOW response: " + string(body))
 	}
 
 	// check for response type
-	rlg := rts["log"].(string)
+	rlg, ok := rts["log"].(string)
+	if !ok {
+		return "", errors.New("could not parse SNOW response log: " + string(body))
+	}
 
 	if strings.Contains(rlg, "Inserting") {
 		log.Printf("SNOW replied with new Change ID: %v", ini)


### PR DESCRIPTION
## Summary
- Changed the `success` field in the notifier payload from a boolean to a string type. ServiceNow was rejecting all change completion/update requests because it received `true` (JSON boolean) instead of `"true"` (string), causing a reference match validation failure.
- Added error response handling in `Notify()` to gracefully handle ServiceNow error responses instead of panicking on a nil type assertion.
- Added a "Completed" status test case to `handler_test.go` to cover the fix.

https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2625